### PR TITLE
[FTP-1667] Allow support for PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-        "php":                           "^7.1",
-        "nikic/php-parser":              "^4.2.1",
+        "php": "^7.4 || ^8.1",
+        "nikic/php-parser": "^4.2.1",
         "ocramius/code-generator-utils": "^1.0.0"
     },
     "autoload": {


### PR DESCRIPTION
In order to allow fishfarm to upgrade to PHP 8.1 we need to allow it from this library as well